### PR TITLE
Update PrepSFCI.ps1

### DIFF
--- a/sql-server-2016-fci-existing-vnet-and-ad/dsc/PrepSFCI.ps1
+++ b/sql-server-2016-fci-existing-vnet-and-ad/dsc/PrepSFCI.ps1
@@ -81,7 +81,7 @@ configuration PrepSFCI
 
         Script CleanSQL
         {
-            SetScript = 'C:\SQLServer_13.0_Full\Setup.exe /Action=Uninstall /FEATURES=SQL,AS,IS,RS /INSTANCENAME=MSSQLSERVER /Q'
+            SetScript = 'C:\SQLServerFull\Setup.exe /Action=Uninstall /FEATURES=SQL,AS,IS,RS /INSTANCENAME=MSSQLSERVER /Q'
             TestScript = '(test-path -Path "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\DATA\master.mdf") -eq $false'
             GetScript = '@{Ensure = if ((test-path -Path "C:\Program Files\Microsoft SQL Server\MSSQL13.MSSQLSERVER\MSSQL\DATA\master.mdf") -eq $false) {"Present"} Else {"Absent"}}'
             DependsOn = "[xComputer]DomainJoin"


### PR DESCRIPTION
In Latest SQL 16 Official Image from Azure Marketplace the SQL Server Setup Media folder changed :
_SQLServer_13.0_Full_ --> _SQLServerFull_

With current implementation, the template deployment fails with :

`[ERROR] PowerShell DSC resource MSFT_ScriptResource  failed to execute Set-TargetResource functionality with error message: The term 'C:\\SQLServer_13.0_Full\\Setup.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.`

I tested this change on private lab environment.

My proposal will patch this issue.